### PR TITLE
add default export in order to use the lib in an es6-ey way

### DIFF
--- a/src/flipdown.js
+++ b/src/flipdown.js
@@ -391,3 +391,5 @@ function appendChildren(parent, children) {
     parent.appendChild(el);
   });
 }
+
+export default FlipDown;


### PR DESCRIPTION
There is no good way to import FlipDown in an ES6 environment. This small addition allows one to have the following syntax:

`import FlipDown from 'flipdown';`
`const flip = new FlipDown()`